### PR TITLE
Documentation and code's style in Backend

### DIFF
--- a/backend/catalogo_arqueologico/catalogo_arqueologico/asgi.py
+++ b/backend/catalogo_arqueologico/catalogo_arqueologico/asgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.asgi import get_asgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'catalogo_arqueologico.settings')
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "catalogo_arqueologico.settings")
 
 application = get_asgi_application()

--- a/backend/catalogo_arqueologico/catalogo_arqueologico/serializer.py
+++ b/backend/catalogo_arqueologico/catalogo_arqueologico/serializer.py
@@ -1,13 +1,43 @@
+"""
+This module defines serializers for the CustomUser model.
+
+It includes the UserSerializer class, which extends the ModelSerializer class from Django REST Framework.
+The UserSerializer class adds a custom field `full_name` to serialize the full name of a user by concatenating
+the first name and last name of the CustomUser model instance.
+"""
+
 from piezas.models import CustomUser
 from rest_framework import serializers
 
 
 class UserSerializer(serializers.ModelSerializer):
+    """
+    Serializer for the CustomUser model.
+
+    Includes a custom field `full_name` that concatenates the user's first and last name.
+
+    Attributes:
+        full_name (SerializerMethodField): A field to represent the user's full name.
+    """
+
     full_name = serializers.SerializerMethodField()
 
     def get_full_name(self, obj):
+        """
+        Returns the full name of the user.
+
+        Parameters:
+            obj (CustomUser): The user instance.
+
+        Returns:
+            str: The full name of the user.
+        """
         return f"{obj.first_name} {obj.last_name}"
 
     class Meta:
+        """
+        Meta class to map serializer's fields with the model fields.
+        """
+
         model = CustomUser
         fields = ["id", "username", "email", "full_name"]

--- a/backend/catalogo_arqueologico/catalogo_arqueologico/serializer.py
+++ b/backend/catalogo_arqueologico/catalogo_arqueologico/serializer.py
@@ -1,13 +1,13 @@
 from piezas.models import CustomUser
 from rest_framework import serializers
 
+
 class UserSerializer(serializers.ModelSerializer):
     full_name = serializers.SerializerMethodField()
-    
+
     def get_full_name(self, obj):
         return f"{obj.first_name} {obj.last_name}"
-    
+
     class Meta:
         model = CustomUser
         fields = ["id", "username", "email", "full_name"]
-

--- a/backend/catalogo_arqueologico/catalogo_arqueologico/serializer.py
+++ b/backend/catalogo_arqueologico/catalogo_arqueologico/serializer.py
@@ -26,7 +26,7 @@ class UserSerializer(serializers.ModelSerializer):
         """
         Returns the full name of the user.
 
-        Parameters:
+        Args:
             obj (CustomUser): The user instance.
 
         Returns:

--- a/backend/catalogo_arqueologico/catalogo_arqueologico/serializer.py
+++ b/backend/catalogo_arqueologico/catalogo_arqueologico/serializer.py
@@ -1,8 +1,10 @@
 """
 This module defines serializers for the CustomUser model.
 
-It includes the UserSerializer class, which extends the ModelSerializer class from Django REST Framework.
-The UserSerializer class adds a custom field `full_name` to serialize the full name of a user by concatenating
+It includes the UserSerializer class, which extends the ModelSerializer class from 
+Django REST Framework.
+The UserSerializer class adds a custom field `full_name` to serialize the full name 
+of a user by concatenating
 the first name and last name of the CustomUser model instance.
 """
 

--- a/backend/catalogo_arqueologico/catalogo_arqueologico/urls.py
+++ b/backend/catalogo_arqueologico/catalogo_arqueologico/urls.py
@@ -6,7 +6,7 @@ from django.conf.urls.static import static
 from catalogo_arqueologico.views import LoginView
 
 urlpatterns = [
-    path('admin/', admin.site.urls),
-    path('auth/', LoginView.as_view()),
-    path('catalog/', include('piezas.urls')),
+    path("admin/", admin.site.urls),
+    path("auth/", LoginView.as_view()),
+    path("catalog/", include("piezas.urls")),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/backend/catalogo_arqueologico/catalogo_arqueologico/urls.py
+++ b/backend/catalogo_arqueologico/catalogo_arqueologico/urls.py
@@ -20,7 +20,7 @@ Imports:
 
 from django.contrib import admin
 from django.urls import path, include
-from rest_framework.authtoken.views import obtain_auth_token
+from rest_framework.authtoken.views import obtain_auth_token # unused import obtain_auth_token
 from django.conf import settings
 from django.conf.urls.static import static
 from catalogo_arqueologico.views import LoginView

--- a/backend/catalogo_arqueologico/catalogo_arqueologico/urls.py
+++ b/backend/catalogo_arqueologico/catalogo_arqueologico/urls.py
@@ -6,12 +6,14 @@ It includes routes for:
 - Authentication via the `LoginView`.
 - The catalog section, which is handled by including URL patterns from the `piezas` application.
 
-Additionally, it configures the serving of media files in development through Django's static serve mechanism.
+Additionally, it configures the serving of media files in development through Django's static serve 
+mechanism.
 
 Imports:
 - `admin` for admin site URLs.
 - `path` and `include` for URL routing.
-- `obtain_auth_token` from Django REST Framework for token authentication (unused in current urlpatterns but available for future use).
+- `obtain_auth_token` from Django REST Framework for token authentication (unused in current 
+    urlpatterns but available for future use).
 - `settings` and `static` for serving media files in development.
 - `LoginView` for authentication views.
 """

--- a/backend/catalogo_arqueologico/catalogo_arqueologico/urls.py
+++ b/backend/catalogo_arqueologico/catalogo_arqueologico/urls.py
@@ -1,3 +1,21 @@
+"""
+This module configures URL patterns for the Django project.
+
+It includes routes for:
+- The Django admin interface.
+- Authentication via the `LoginView`.
+- The catalog section, which is handled by including URL patterns from the `piezas` application.
+
+Additionally, it configures the serving of media files in development through Django's static serve mechanism.
+
+Imports:
+- `admin` for admin site URLs.
+- `path` and `include` for URL routing.
+- `obtain_auth_token` from Django REST Framework for token authentication (unused in current urlpatterns but available for future use).
+- `settings` and `static` for serving media files in development.
+- `LoginView` for authentication views.
+"""
+
 from django.contrib import admin
 from django.urls import path, include
 from rest_framework.authtoken.views import obtain_auth_token

--- a/backend/catalogo_arqueologico/catalogo_arqueologico/views.py
+++ b/backend/catalogo_arqueologico/catalogo_arqueologico/views.py
@@ -29,7 +29,7 @@ class LoginView(APIView):
 
         This method checks if the request data includes 'email' and 'password'.
 
-        Parameters:
+        Args:
             request (HttpRequest): The request object containing the email and password.
 
         Returns:

--- a/backend/catalogo_arqueologico/catalogo_arqueologico/views.py
+++ b/backend/catalogo_arqueologico/catalogo_arqueologico/views.py
@@ -21,14 +21,6 @@ class LoginView(APIView):
     This view handles POST requests to authenticate users. It expects an email and password
     in the request data, validates them, and returns a token for authenticated sessions along
     with user data if the credentials are valid.
-
-    Methods:
-        post(request): Handles the POST request to authenticate a user.
-            - Parameters:
-                - request: HttpRequest object containing the request data.
-            - Returns:
-                - Response object with token and user data if authentication is successful.
-                - Response object with error detail if authentication fails.
     """
 
     def post(self, request):

--- a/backend/catalogo_arqueologico/catalogo_arqueologico/views.py
+++ b/backend/catalogo_arqueologico/catalogo_arqueologico/views.py
@@ -6,12 +6,12 @@ handles POST requests, authenticating users based on email and password, and ret
 for authenticated sessions.
 """
 
-from piezas.models import CustomUser
-from .serializer import UserSerializer
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework.authtoken.models import Token
+from piezas.models import CustomUser
+from .serializer import UserSerializer
 
 
 class LoginView(APIView):

--- a/backend/catalogo_arqueologico/catalogo_arqueologico/views.py
+++ b/backend/catalogo_arqueologico/catalogo_arqueologico/views.py
@@ -1,3 +1,11 @@
+"""
+This module contains views for the user authentication system.
+
+It includes the LoginView class, which provides an API endpoint for user login. The LoginView
+handles POST requests, authenticating users based on email and password, and returns a token
+for authenticated sessions.
+"""
+
 from piezas.models import CustomUser
 from .serializer import UserSerializer
 from rest_framework import status
@@ -7,7 +15,36 @@ from rest_framework.authtoken.models import Token
 
 
 class LoginView(APIView):
+    """
+    API View for user login.
+
+    This view handles POST requests to authenticate users. It expects an email and password
+    in the request data, validates them, and returns a token for authenticated sessions along
+    with user data if the credentials are valid.
+
+    Methods:
+        post(request): Handles the POST request to authenticate a user.
+            - Parameters:
+                - request: HttpRequest object containing the request data.
+            - Returns:
+                - Response object with token and user data if authentication is successful.
+                - Response object with error detail if authentication fails.
+    """
+
     def post(self, request):
+        """
+        Authenticate a user based on email and password.
+
+        This method checks if the request data includes 'email' and 'password'.
+
+        Parameters:
+            request (HttpRequest): The request object containing the email and password.
+
+        Returns:
+            Response: A DRF Response object with the authentication token and user data if the login
+            is successful, or an error message if the login fails.
+        """
+
         if "email" not in self.request.data or "password" not in self.request.data:
             return Response(
                 {"detail": "Ingrese correo y contraseña"},

--- a/backend/catalogo_arqueologico/catalogo_arqueologico/wsgi.py
+++ b/backend/catalogo_arqueologico/catalogo_arqueologico/wsgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'catalogo_arqueologico.settings')
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "catalogo_arqueologico.settings")
 
 application = get_wsgi_application()

--- a/backend/catalogo_arqueologico/piezas/admin.py
+++ b/backend/catalogo_arqueologico/piezas/admin.py
@@ -72,7 +72,7 @@ class CustomUserAdmin(UserAdmin):
         """
         Returns a comma-separated string of the user's groups.
 
-        Parameters:
+        Args:
             obj (CustomUser): The user instance.
 
         Returns:
@@ -87,7 +87,7 @@ class CustomUserAdmin(UserAdmin):
         """
         Saves the model instance and updates the user's group memberships.
 
-        Parameters:
+        Args:
             request (HttpRequest): The HTTP request instance.
             obj (CustomUser): The user instance being saved.
             form (ModelForm): The form instance.
@@ -102,7 +102,7 @@ class CustomUserAdmin(UserAdmin):
         """
         Handles the response after a change has been made to a user instance.
 
-        Parameters:
+        Args:
             request (HttpRequest): The HTTP request instance.
             obj (CustomUser): The user instance that was changed.
 

--- a/backend/catalogo_arqueologico/piezas/admin.py
+++ b/backend/catalogo_arqueologico/piezas/admin.py
@@ -16,6 +16,18 @@ from .forms import CustomUserCreationForm, CustomUserChangeForm
 
 
 class CustomUserAdmin(UserAdmin):
+    """
+    Custom user model admin that represents the CustomUser model in the Django admin interface.
+    
+    Attributes:
+        add_form (forms.ModelForm): The form used for creating new users.
+        form (forms.ModelForm): The form used for changing user information.
+        model (models.Model): The CustomUser model.
+        list_display (list): A list of field names to display in the user list page.
+        list_filter (tuple): A tuple of field names to filter by in the user list page.
+        fieldsets (tuple): A tuple specifying the layout of the admin “change” page.
+        add_fieldsets (tuple): A tuple specifying the layout of the admin “add” page.
+    """
     add_form = CustomUserCreationForm
     form = CustomUserChangeForm
     model = CustomUser
@@ -39,43 +51,101 @@ class CustomUserAdmin(UserAdmin):
     )
 
     def get_groups(self, obj):
+        """
+        Returns a comma-separated string of the user's groups.
+        
+        Parameters:
+            obj (CustomUser): The user instance.
+            
+        Returns:
+            str: A comma-separated string of group names.
+        """
         return ", ".join([group.name for group in obj.groups.all()])
 
     get_groups.short_description = "Groups"
 
     def save_model(self, request, obj, form, change):
+        """
+        Saves the model instance and updates the user's group memberships.
+        
+        Parameters:
+            request (HttpRequest): The HTTP request instance.
+            obj (CustomUser): The user instance being saved.
+            form (ModelForm): The form instance.
+            change (bool): True if this is a change operation, False if this is a creation operation.
+        """
         super().save_model(request, obj, form, change)
         obj.update_group()
 
     def response_change(self, request, obj):
+        """
+        Handles the response after a change has been made to a user instance.
+        
+        Parameters:
+            request (HttpRequest): The HTTP request instance.
+            obj (CustomUser): The user instance that was changed.
+            
+        Returns:
+            HttpResponse: The HTTP response to send back to the client.
+        """
         response = super().response_change(request, obj)
         obj.update_group()
         return response
 
 
 class TagAdmin(admin.ModelAdmin):
+    """
+    Admin interface options for Tag model.
+    
+    Attributes:
+        list_display (tuple): Fields to display in the admin list view.
+        list_filter (tuple): Fields to filter by in the admin list view.
+        search_fields (tuple): Fields to search in the admin list view.
+    """
     list_display = ("id", "name")
     list_filter = ("name",)
     search_fields = ("name",)
 
 
 class ShapeAdmin(admin.ModelAdmin):
+    """
+    Admin interface options for Shape model.
+    
+    Attributes:
+        list_display (tuple): Fields to display in the admin list view.
+        list_filter (tuple): Fields to filter by in the admin list view.
+        search_fields (tuple): Fields to search in the admin list view.
+    """
     list_display = ("id", "name")
     list_filter = ("name",)
     search_fields = ("name",)
 
-
 class CultureAdmin(admin.ModelAdmin):
+    """
+    Admin interface options for Culture model.
+    
+    Attributes:
+        list_display (tuple): Fields to display in the admin list view.
+        list_filter (tuple): Fields to filter by in the admin list view.
+        search_fields (tuple): Fields to search in the admin list view.
+    """
     list_display = ("id", "name")
     list_filter = ("name",)
     search_fields = ("name",)
 
 
 class ArtifactAdmin(admin.ModelAdmin):
+    """
+    Admin interface options for Artifact model.
+    
+    Attributes:
+        list_display (tuple): Fields to display in the admin list view.
+        list_filter (tuple): Fields to filter by in the admin list view.
+        search_fields (tuple): Fields to search in the admin list view.
+    """
     list_display = ("id", "description")
     list_filter = ("id",)
     search_fields = ("description",)
-
 
 admin.site.register(CustomUser, CustomUserAdmin)
 admin.site.register(Tag, TagAdmin)

--- a/backend/catalogo_arqueologico/piezas/admin.py
+++ b/backend/catalogo_arqueologico/piezas/admin.py
@@ -18,7 +18,7 @@ from .forms import CustomUserCreationForm, CustomUserChangeForm
 class CustomUserAdmin(UserAdmin):
     """
     Custom user model admin that represents the CustomUser model in the Django admin interface.
-    
+
     Attributes:
         add_form (forms.ModelForm): The form used for creating new users.
         form (forms.ModelForm): The form used for changing user information.
@@ -28,6 +28,7 @@ class CustomUserAdmin(UserAdmin):
         fieldsets (tuple): A tuple specifying the layout of the admin “change” page.
         add_fieldsets (tuple): A tuple specifying the layout of the admin “add” page.
     """
+
     add_form = CustomUserCreationForm
     form = CustomUserChangeForm
     model = CustomUser
@@ -53,10 +54,10 @@ class CustomUserAdmin(UserAdmin):
     def get_groups(self, obj):
         """
         Returns a comma-separated string of the user's groups.
-        
+
         Parameters:
             obj (CustomUser): The user instance.
-            
+
         Returns:
             str: A comma-separated string of group names.
         """
@@ -67,7 +68,7 @@ class CustomUserAdmin(UserAdmin):
     def save_model(self, request, obj, form, change):
         """
         Saves the model instance and updates the user's group memberships.
-        
+
         Parameters:
             request (HttpRequest): The HTTP request instance.
             obj (CustomUser): The user instance being saved.
@@ -80,11 +81,11 @@ class CustomUserAdmin(UserAdmin):
     def response_change(self, request, obj):
         """
         Handles the response after a change has been made to a user instance.
-        
+
         Parameters:
             request (HttpRequest): The HTTP request instance.
             obj (CustomUser): The user instance that was changed.
-            
+
         Returns:
             HttpResponse: The HTTP response to send back to the client.
         """
@@ -96,12 +97,13 @@ class CustomUserAdmin(UserAdmin):
 class TagAdmin(admin.ModelAdmin):
     """
     Admin interface options for Tag model.
-    
+
     Attributes:
         list_display (tuple): Fields to display in the admin list view.
         list_filter (tuple): Fields to filter by in the admin list view.
         search_fields (tuple): Fields to search in the admin list view.
     """
+
     list_display = ("id", "name")
     list_filter = ("name",)
     search_fields = ("name",)
@@ -110,25 +112,28 @@ class TagAdmin(admin.ModelAdmin):
 class ShapeAdmin(admin.ModelAdmin):
     """
     Admin interface options for Shape model.
-    
+
     Attributes:
         list_display (tuple): Fields to display in the admin list view.
         list_filter (tuple): Fields to filter by in the admin list view.
         search_fields (tuple): Fields to search in the admin list view.
     """
+
     list_display = ("id", "name")
     list_filter = ("name",)
     search_fields = ("name",)
 
+
 class CultureAdmin(admin.ModelAdmin):
     """
     Admin interface options for Culture model.
-    
+
     Attributes:
         list_display (tuple): Fields to display in the admin list view.
         list_filter (tuple): Fields to filter by in the admin list view.
         search_fields (tuple): Fields to search in the admin list view.
     """
+
     list_display = ("id", "name")
     list_filter = ("name",)
     search_fields = ("name",)
@@ -137,15 +142,17 @@ class CultureAdmin(admin.ModelAdmin):
 class ArtifactAdmin(admin.ModelAdmin):
     """
     Admin interface options for Artifact model.
-    
+
     Attributes:
         list_display (tuple): Fields to display in the admin list view.
         list_filter (tuple): Fields to filter by in the admin list view.
         search_fields (tuple): Fields to search in the admin list view.
     """
+
     list_display = ("id", "description")
     list_filter = ("id",)
     search_fields = ("description",)
+
 
 admin.site.register(CustomUser, CustomUserAdmin)
 admin.site.register(Tag, TagAdmin)

--- a/backend/catalogo_arqueologico/piezas/admin.py
+++ b/backend/catalogo_arqueologico/piezas/admin.py
@@ -1,3 +1,20 @@
+"""
+This module defines the admin interface customization for the Django application.
+
+It includes custom admin classes for the CustomUser model and other models such 
+as Tag, Shape, Culture, and Artifact.
+
+Classes:
+    CustomUserAdmin: Customizes the admin interface for the CustomUser model.
+    TagAdmin: Customizes the admin interface for the Tag model.
+    ShapeAdmin: Customizes the admin interface for the Shape model.
+    CultureAdmin: Customizes the admin interface for the Culture model.
+    ArtifactAdmin: Customizes the admin interface for the Artifact model.
+
+The module also registers these models with the Django admin to make them available in 
+the Django admin panel.
+"""
+
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
 from .models import (
@@ -61,6 +78,7 @@ class CustomUserAdmin(UserAdmin):
         Returns:
             str: A comma-separated string of group names.
         """
+
         return ", ".join([group.name for group in obj.groups.all()])
 
     get_groups.short_description = "Groups"
@@ -73,8 +91,10 @@ class CustomUserAdmin(UserAdmin):
             request (HttpRequest): The HTTP request instance.
             obj (CustomUser): The user instance being saved.
             form (ModelForm): The form instance.
-            change (bool): True if this is a change operation, False if this is a creation operation.
+            change (bool): True if this is a change operation,
+                False if this is a creation operation.
         """
+
         super().save_model(request, obj, form, change)
         obj.update_group()
 
@@ -89,6 +109,7 @@ class CustomUserAdmin(UserAdmin):
         Returns:
             HttpResponse: The HTTP response to send back to the client.
         """
+
         response = super().response_change(request, obj)
         obj.update_group()
         return response

--- a/backend/catalogo_arqueologico/piezas/apps.py
+++ b/backend/catalogo_arqueologico/piezas/apps.py
@@ -2,5 +2,5 @@ from django.apps import AppConfig
 
 
 class PiezasConfig(AppConfig):
-    default_auto_field = 'django.db.models.BigAutoField'
-    name = 'piezas'
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "piezas"

--- a/backend/catalogo_arqueologico/piezas/apps.py
+++ b/backend/catalogo_arqueologico/piezas/apps.py
@@ -1,6 +1,26 @@
+"""
+This module defines the Django application configuration for the 'piezas' app.
+
+The PiezasConfig class inherits from AppConfig, providing metadata and 
+configuration options for the 'piezas' application.
+"""
+
 from django.apps import AppConfig
 
 
 class PiezasConfig(AppConfig):
+    """
+    Defines the Django application configuration for the 'piezas' app.
+
+    This class configures the 'piezas' application within a Django project.
+    It specifies settings that affect the app's behavior within the project.
+
+    Attributes:
+        default_auto_field (str): Specifies the type of auto-created primary keys.
+        name (str): The name of the application. It is used by Django to identify
+            the application. Here, it is set to 'piezas', which should match the
+            name of the Python package for the app.
+    """
+
     default_auto_field = "django.db.models.BigAutoField"
     name = "piezas"

--- a/backend/catalogo_arqueologico/piezas/authentication.py
+++ b/backend/catalogo_arqueologico/piezas/authentication.py
@@ -1,5 +1,27 @@
+"""
+This module customizes the token authentication mechanism provided by Django REST Framework.
+
+By subclassing the `TokenAuthentication` class from Django REST Framework, it modifies the 
+authentication keyword to "Bearer". 
+
+"""
+
 from rest_framework.authentication import TokenAuthentication as BaseTokenAuth
 
 
 class TokenAuthentication(BaseTokenAuth):
+    """
+    Customizes the token authentication mechanism to use the "Bearer" token format.
+
+    This class inherits from Django REST Framework's `TokenAuthentication` class,
+    overriding the default authentication keyword from "Token" to "Bearer".
+    This modification aligns the authentication scheme with the commonly used
+    Bearer token format in Authorization headers for APIs, facilitating integration
+    with clients and services that follow this standard.
+
+    Attributes:
+        keyword (str): The authentication keyword used in the Authorization header,
+            set to "Bearer" to indicate the Bearer token format.
+    """
+
     keyword = "Bearer"

--- a/backend/catalogo_arqueologico/piezas/forms.py
+++ b/backend/catalogo_arqueologico/piezas/forms.py
@@ -1,14 +1,83 @@
+"""
+This module extends Django's built-in user forms to accommodate a custom user model.
+
+It defines two forms for creating and modifying instances of a CustomUser model. 
+These forms are used within the Django admin site or any view that requires user 
+creation or modification functionality with fields specific to the CustomUser model.
+
+Classes:
+    CustomUserCreationForm: A form for creating new users.
+
+    CustomUserChangeForm: A form for updating existing users. 
+
+Both forms inherit from Django's built-in UserCreationForm and UserChangeForm, 
+respectively, ensuring that user instances are properly created and modified 
+within the framework's user management system.
+"""
+
 from django.contrib.auth.forms import UserCreationForm, UserChangeForm
 from .models import CustomUser
 
 
 class CustomUserCreationForm(UserCreationForm):
+    """
+    A form for creating new users with the CustomUser model.
+
+    Inherits from Django's UserCreationForm and specifies the CustomUser model
+    and a set of fields to be included in the form. This form is designed to
+    include additional fields ('role', 'rut', 'institution') beyond the default
+    user model, allowing for the collection of extra information during the user creation process.
+
+    Attributes:
+        Meta: A class containing configuration for this form class.
+    """
+
     class Meta:
+        """
+        Configuration class for CustomUserCreationForm.
+
+        Specifies the model to be used as the basis for the form and the fields to be
+        included in the form. This configuration ensures that the form will be populated
+        with the appropriate fields for creating a new CustomUser instance.
+
+        Attributes:
+            model (CustomUser): The model that this form will create instances of.
+            fields (tuple): The fields to be included in the form. This includes 'username',
+                'role', 'rut', 'institution', 'password1', and 'password2', allowing for
+                comprehensive user creation.
+        """
+
         model = CustomUser
         fields = ("username", "role", "rut", "institution", "password1", "password2")
 
 
 class CustomUserChangeForm(UserChangeForm):
+    """
+    A form for updating existing users using the CustomUser model.
+
+    Inherits from Django's UserChangeForm and specifies the CustomUser model and a
+    subset of fields that can be edited. This form is typically used within the Django
+    admin to allow administrators to edit existing user information, including custom
+    fields defined in the CustomUser model.
+
+    Attributes:
+        Meta: A class containing configuration for this form class.
+    """
+
     class Meta:
+        """
+        Configuration class for CustomUserChangeForm.
+
+        Specifies the model to be used as the basis for the form and the fields that can
+        be edited. This configuration is used to ensure that the form allows for editing
+        of existing CustomUser instances with the specified fields.
+
+        Attributes:
+            model (CustomUser): The model that this form will edit instances of.
+            fields (tuple): The fields that are editable in this form. This includes 'username',
+                'role', 'rut', and 'institution', focusing on the essential user information that
+                might need to be updated.
+        """
+
         model = CustomUser
         fields = ("username", "role", "rut", "institution")

--- a/backend/catalogo_arqueologico/piezas/management/commands/createGroups.py
+++ b/backend/catalogo_arqueologico/piezas/management/commands/createGroups.py
@@ -1,3 +1,6 @@
+"""
+This module contains a Django management command that creates groups and assigns permissions to them.
+""""
 from django.contrib.auth.models import Group, Permission
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Q
@@ -10,9 +13,19 @@ logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
+    """
+    This command creates groups and assigns permissions to them.
+
+    Attributes:
+        help (str): A short description of the command that is displayed when running
+            'python manage.py help createGroups'.
+    """
     help = "Creates specified groups and assigns permissions"
 
     def handle(self, *args, **options):
+        """
+        Executes the command to create groups and assign permissions.
+        """	
         groups = ["Funcionario", "Administrador"]
         for group_name in groups:
             group, created = Group.objects.get_or_create(name=group_name)

--- a/backend/catalogo_arqueologico/piezas/management/commands/importAllData.py
+++ b/backend/catalogo_arqueologico/piezas/management/commands/importAllData.py
@@ -1,3 +1,7 @@
+"""
+This module contains the command that executes every other command related to imports.
+"""
+
 from django.core.management.base import BaseCommand
 from django.core import management
 from django.core.management.base import BaseCommand
@@ -12,10 +16,20 @@ logger.setLevel("INFO")
 
 
 class Command(BaseCommand):
+    """
+    This command executes every other command related to imports.
+
+    Attributes:
+        help (str): A short description of the command that is displayed when running
+            'python manage.py help importAllData'.
+    """
+
     help = "This command executes every other command related to imports. Doesn't need any arguments."
 
     def handle(self, *args, **kwargs):
-
+        """
+        Executes every other command related to imports.
+        """
         # Get every shape txt file, to run importShape with that file
         shapes_txt_folder = os.listdir(settings.SHAPE_FOLDER_PATH)
         shapes_txt = [

--- a/backend/catalogo_arqueologico/piezas/management/commands/importCulture.py
+++ b/backend/catalogo_arqueologico/piezas/management/commands/importCulture.py
@@ -1,3 +1,7 @@
+"""	
+This module contains a command to import cultures from a CSV file.
+"""
+
 import os
 from django.core.management.base import BaseCommand
 from django.db import IntegrityError
@@ -11,9 +15,20 @@ logger.setLevel("INFO")
 
 
 class Command(BaseCommand):
+    """
+    This command imports cultures from a CSV file.
+
+    Attributes:
+        help (str): A short description of the command that is displayed when running
+            'python manage.py help importCulture'.
+    """
+
     help = "Import cultures from a CSV file. The CSV file must contain a list of ids and cultures."
 
     def handle(self, *args, **kwargs):
+        """
+        Executes the command to import cultures from a CSV file.
+        """
         file = settings.CULTURE_CSV_PATH
         if not os.path.exists(file):
             logger.error(f"File {file} not found. Stop")

--- a/backend/catalogo_arqueologico/piezas/management/commands/importDescriptions.py
+++ b/backend/catalogo_arqueologico/piezas/management/commands/importDescriptions.py
@@ -1,3 +1,6 @@
+"""	
+This module contains a Django management command that imports descriptions from a CSV file.
+"""
 from django.core.management.base import BaseCommand
 from django.db import IntegrityError
 from django.core.files import File
@@ -14,6 +17,16 @@ logger.setLevel("INFO")
 
 
 def addImages(self, artifact, realId):
+    """
+    This function adds images to an artifact.
+
+    Args:
+        artifact (Artifact): The artifact to which the images will be added.
+        realId (str): The realId of the artifact.
+
+    Returns:
+        None    
+    """
     multimedia_path = settings.MULTIMEDIA_FOLDER_PATH
 
     if not os.path.exists(multimedia_path):
@@ -45,9 +58,20 @@ def addImages(self, artifact, realId):
 
 
 class Command(BaseCommand):
+    """
+    This command imports descriptions from a CSV file.
+
+    Attributes:
+        help (str): A short description of the command that is displayed when running
+            'python manage.py help importDescriptions'.
+    """
+
     help = "Import descriptions from a CSV file. The CSV file must contain a list of ids and descriptions."
 
     def handle(self, *args, **kwargs):
+        """
+        Executes the command to import descriptions from a CSV file.
+        """
         descriptions_file = settings.DESCRIPTIONS_CSV_PATH
         if not os.path.exists(descriptions_file):
             logger.error(f"File {descriptions_file} not found. Stop")

--- a/backend/catalogo_arqueologico/piezas/management/commands/importDescriptions.py
+++ b/backend/catalogo_arqueologico/piezas/management/commands/importDescriptions.py
@@ -1,6 +1,7 @@
 """	
 This module contains a Django management command that imports descriptions from a CSV file.
 """
+
 from django.core.management.base import BaseCommand
 from django.db import IntegrityError
 from django.core.files import File
@@ -25,7 +26,7 @@ def addImages(self, artifact, realId):
         realId (str): The realId of the artifact.
 
     Returns:
-        None    
+        None
     """
     multimedia_path = settings.MULTIMEDIA_FOLDER_PATH
 
@@ -84,9 +85,7 @@ class Command(BaseCommand):
                 descriptionArtifact = artifact_description_tuple[1].strip()
                 # Get the thumbnail, model, shape, culture, tags
                 # (these models are already created)
-                idThumbnail = Thumbnail.objects.get(
-                    path__icontains=realId
-                )
+                idThumbnail = Thumbnail.objects.get(path__icontains=realId)
                 idModel = Model.objects.filter(
                     Q(texture__icontains=realId)
                     & Q(object__icontains=realId)
@@ -99,7 +98,7 @@ class Command(BaseCommand):
 
                 realShape = Shape.objects.get(id=idShape.shape)
                 realCulture = Culture.objects.get(id=idCulture.culture)
-                
+
                 try:
                     # Create artifact object
                     newArtifact = Artifact.objects.create(

--- a/backend/catalogo_arqueologico/piezas/management/commands/importDescriptions.py
+++ b/backend/catalogo_arqueologico/piezas/management/commands/importDescriptions.py
@@ -1,5 +1,5 @@
 """	
-This module contains a Django management command that imports descriptions from a CSV file.
+This module contains a Django management command that imports descriptions from a CSV file. After importing the descriptions, the command creates the artifacts, adding images to them if they have.
 """
 
 from django.core.management.base import BaseCommand
@@ -23,7 +23,7 @@ def addImages(self, artifact, realId):
 
     Args:
         artifact (Artifact): The artifact to which the images will be added.
-        realId (str): The realId of the artifact.
+        realId (str): The id of the artifact.
 
     Returns:
         None
@@ -60,14 +60,14 @@ def addImages(self, artifact, realId):
 
 class Command(BaseCommand):
     """
-    This command imports descriptions from a CSV file.
+    This command imports descriptions from a CSV file, creating an artifact for each description.
 
     Attributes:
         help (str): A short description of the command that is displayed when running
             'python manage.py help importDescriptions'.
     """
 
-    help = "Import descriptions from a CSV file. The CSV file must contain a list of ids and descriptions."
+    help = "Import descriptions from a CSV file, creating an artifact for each description. The CSV file must contain a list of ids and descriptions."
 
     def handle(self, *args, **kwargs):
         """

--- a/backend/catalogo_arqueologico/piezas/management/commands/importInstitutions.py
+++ b/backend/catalogo_arqueologico/piezas/management/commands/importInstitutions.py
@@ -11,9 +11,19 @@ logger = logging.getLogger(__name__)
 logger.setLevel("INFO")
 
 class Command(BaseCommand):
+    """
+    This command reads csv with institutions. It is necessary to specify which column is the one with the name.
+
+    Attributes:
+        help (str): A short description of the command that is displayed when running
+            'python manage.py help importInstitutions'.
+    """
     help = "This command reads csv with institutions. It is necessary to specify which column is the one with the name"
 
     def handle(self, *args, **kwargs):
+        """
+        Executes the command to import institutions from a CSV file.
+        """
         file = settings.INSTITUTIONS_CSV_PATH
         if not os.path.exists(file):
             logger.error(f"File {file} not found. Stop")

--- a/backend/catalogo_arqueologico/piezas/management/commands/importInstitutions.py
+++ b/backend/catalogo_arqueologico/piezas/management/commands/importInstitutions.py
@@ -1,8 +1,11 @@
+"""
+This module contains the command that imports institutions from a CSV file.
+"""
+
 from django.core.management.base import BaseCommand
 from django.db import IntegrityError
 from django.conf import settings
 from piezas.models import Institution
-
 import os
 import logging
 import csv
@@ -13,20 +16,36 @@ logger.setLevel("INFO")
 
 class Command(BaseCommand):
     """
-    This command reads csv with institutions. It is necessary to specify which column is the one with the name.
+    This command reads csv with institutions. It can be specified which column is the one with the name by using a zero-based numbering.
 
     Attributes:
-        help (str): A short description of the command that is displayed when running
-            'python manage.py help importInstitutions'.
+    help (str): A short description of the command that is displayed when running
+    'python manage.py help importInstitutions'.
     """
 
-    help = "This command reads csv with institutions. It is necessary to specify which column is the one with the name"
+    help = "This command reads csv with institutions. It can be specified which column is the one with the name by using a zero-based numbering."
+
+    def add_arguments(self, parser):
+        """
+        Adds the column argument to the command.
+
+        Args:
+        parser (ArgumentParser): The parser that will receive the arguments.
+        """
+        parser.add_argument(
+            "--column",
+            type=int,
+            default=3,
+            help="The column number (zero-based) containing the institution name. Default is 3.",
+        )
 
     def handle(self, *args, **kwargs):
         """
         Executes the command to import institutions from a CSV file.
         """
         file = settings.INSTITUTIONS_CSV_PATH
+        column = kwargs["column"]
+
         if not os.path.exists(file):
             logger.error(f"File {file} not found. Stop")
             return
@@ -35,8 +54,9 @@ class Command(BaseCommand):
             institutions = csv.reader(archivo_csv, delimiter=",")
             for institution in institutions:
                 try:
-                    recentlyAdded = Institution.objects.create(name=institution[3])
+                    recentlyAdded = Institution.objects.create(name=institution[column])
+                    logger.info(f"Institution {recentlyAdded.name} created")
                 except IntegrityError:
                     logger.info(
-                        f"Institution {institution[3]} already exists. Skipping its creation"
+                        f"Institution {institution[column]} already exists. Skipping its creation"
                     )

--- a/backend/catalogo_arqueologico/piezas/management/commands/importInstitutions.py
+++ b/backend/catalogo_arqueologico/piezas/management/commands/importInstitutions.py
@@ -10,6 +10,7 @@ import csv
 logger = logging.getLogger(__name__)
 logger.setLevel("INFO")
 
+
 class Command(BaseCommand):
     """
     This command reads csv with institutions. It is necessary to specify which column is the one with the name.
@@ -18,6 +19,7 @@ class Command(BaseCommand):
         help (str): A short description of the command that is displayed when running
             'python manage.py help importInstitutions'.
     """
+
     help = "This command reads csv with institutions. It is necessary to specify which column is the one with the name"
 
     def handle(self, *args, **kwargs):
@@ -33,12 +35,8 @@ class Command(BaseCommand):
             institutions = csv.reader(archivo_csv, delimiter=",")
             for institution in institutions:
                 try:
-                    recentlyAdded = Institution.objects.create(
-                        name=institution[3]
-                    )
+                    recentlyAdded = Institution.objects.create(name=institution[3])
                 except IntegrityError:
                     logger.info(
                         f"Institution {institution[3]} already exists. Skipping its creation"
                     )
-
-

--- a/backend/catalogo_arqueologico/piezas/management/commands/importModel3D.py
+++ b/backend/catalogo_arqueologico/piezas/management/commands/importModel3D.py
@@ -1,6 +1,7 @@
 """
 This module contains a Django management command to import 3D models from a folder.
 """
+
 from django.core.management.base import BaseCommand
 from django.core.files import File
 from django.conf import settings
@@ -19,10 +20,10 @@ class Command(BaseCommand):
     This command imports 3D models from a folder.
 
     Attributes:
-        help (str): A short description of the command that is displayed when running           
+        help (str): A short description of the command that is displayed when running
             'python manage.py help importModel3D'.
     """
-    
+
     help = "Import 3D models from a folder. The folder must contain .obj, .mtl and .png files with the same name."
 
     def handle(self, *args, **kwargs):

--- a/backend/catalogo_arqueologico/piezas/management/commands/importModel3D.py
+++ b/backend/catalogo_arqueologico/piezas/management/commands/importModel3D.py
@@ -1,3 +1,6 @@
+"""
+This module contains a Django management command to import 3D models from a folder.
+"""
 from django.core.management.base import BaseCommand
 from django.core.files import File
 from django.conf import settings
@@ -12,9 +15,20 @@ logger.setLevel("INFO")
 
 
 class Command(BaseCommand):
+    """
+    This command imports 3D models from a folder.
+
+    Attributes:
+        help (str): A short description of the command that is displayed when running           
+            'python manage.py help importModel3D'.
+    """
+    
     help = "Import 3D models from a folder. The folder must contain .obj, .mtl and .png files with the same name."
 
     def handle(self, *args, **kwargs):
+        """
+        Executes the command to import 3D models from a folder.
+        """
         model_folder = settings.MODEL_FOLDER_PATH
         if not os.path.exists(model_folder):
             logger.error(f"Folder {model_folder} not found. Stop")

--- a/backend/catalogo_arqueologico/piezas/management/commands/importShape.py
+++ b/backend/catalogo_arqueologico/piezas/management/commands/importShape.py
@@ -1,6 +1,7 @@
 """
 This module contains the command to import shapes from a txt file.
 """
+
 from django.core.management.base import BaseCommand
 from django.db import IntegrityError
 from django.conf import settings
@@ -21,6 +22,7 @@ class Command(BaseCommand):
         help (str): A short description of the command that is displayed when running
             'python manage.py help importShape'.
     """
+
     help = "Import shapes from a txt file. The file must contain a list of ids. The file name will be the shape name and the file content will be the artifact ids."
 
     def add_arguments(self, parser):
@@ -28,7 +30,7 @@ class Command(BaseCommand):
         Adds the file argument to the command.
 
         Args:
-            parser (ArgumentParser): The parser that will receive the arguments.    
+            parser (ArgumentParser): The parser that will receive the arguments.
         """
         parser.add_argument("file", type=str, help="The argument file is required")
 

--- a/backend/catalogo_arqueologico/piezas/management/commands/importShape.py
+++ b/backend/catalogo_arqueologico/piezas/management/commands/importShape.py
@@ -1,3 +1,6 @@
+"""
+This module contains the command to import shapes from a txt file.
+"""
 from django.core.management.base import BaseCommand
 from django.db import IntegrityError
 from django.conf import settings
@@ -11,12 +14,28 @@ logger.setLevel("INFO")
 
 
 class Command(BaseCommand):
+    """
+    This command imports shapes from a txt file.
+
+    Attributes:
+        help (str): A short description of the command that is displayed when running
+            'python manage.py help importShape'.
+    """
     help = "Import shapes from a txt file. The file must contain a list of ids. The file name will be the shape name and the file content will be the artifact ids."
 
     def add_arguments(self, parser):
+        """
+        Adds the file argument to the command.
+
+        Args:
+            parser (ArgumentParser): The parser that will receive the arguments.    
+        """
         parser.add_argument("file", type=str, help="The argument file is required")
 
     def handle(self, *args, **kwargs):
+        """
+        Executes the command to import shapes from a txt file.
+        """
         folder_path = settings.SHAPE_FOLDER_PATH
         file_name = kwargs.get("file")
         file = folder_path + file_name

--- a/backend/catalogo_arqueologico/piezas/management/commands/importTags.py
+++ b/backend/catalogo_arqueologico/piezas/management/commands/importTags.py
@@ -1,3 +1,6 @@
+"""
+This module contains a Django management command that imports tags from a CSV file.
+"""
 import os
 from django.core.management.base import BaseCommand
 from django.db import IntegrityError
@@ -11,11 +14,21 @@ logger.setLevel("INFO")
 
 
 class Command(BaseCommand):
+    """
+    This command imports tags from a CSV file.
+
+    Attributes:
+        help (str): A short description of the command that is displayed when running
+            'python manage.py help import
+    """
     help = (
         "Import tags from a CSV file. The CSV file must contain a list of ids and tags."
     )
 
     def handle(self, *args, **kwargs):
+        """
+        Executes the command to import tags from a CSV file.
+        """
         file = settings.TAGS_CSV_PATH
         if not os.path.exists(file):
             logger.error(f"File {file} not found. Stop")

--- a/backend/catalogo_arqueologico/piezas/management/commands/importTags.py
+++ b/backend/catalogo_arqueologico/piezas/management/commands/importTags.py
@@ -20,7 +20,7 @@ class Command(BaseCommand):
 
     Attributes:
         help (str): A short description of the command that is displayed when running
-            'python manage.py help import
+            'python manage.py help importTags'.
     """
 
     help = (

--- a/backend/catalogo_arqueologico/piezas/management/commands/importTags.py
+++ b/backend/catalogo_arqueologico/piezas/management/commands/importTags.py
@@ -1,6 +1,7 @@
 """
 This module contains a Django management command that imports tags from a CSV file.
 """
+
 import os
 from django.core.management.base import BaseCommand
 from django.db import IntegrityError
@@ -21,6 +22,7 @@ class Command(BaseCommand):
         help (str): A short description of the command that is displayed when running
             'python manage.py help import
     """
+
     help = (
         "Import tags from a CSV file. The CSV file must contain a list of ids and tags."
     )
@@ -42,7 +44,7 @@ class Command(BaseCommand):
             for artifact_tags_tuple in artifact_tags_relationships:
                 artifactId = int(artifact_tags_tuple[0])
                 tags = artifact_tags_tuple[1].split(", ")
-                tags= [tag.strip() for tag in tags]
+                tags = [tag.strip() for tag in tags]
 
                 for tag in tags:
                     if tag not in tag_artifactIds:

--- a/backend/catalogo_arqueologico/piezas/management/commands/importThumbs.py
+++ b/backend/catalogo_arqueologico/piezas/management/commands/importThumbs.py
@@ -11,9 +11,20 @@ logger.setLevel("INFO")
 
 
 class Command(BaseCommand):
+    """
+    This command imports thumbnails from a folder.
+
+    Attributes:
+        help (str): A short description of the command that is displayed when running
+            'python manage.py help importThumbs'.
+    """
+
     help = "Import thumbnails from a folder. The folder must contain photo type files."
 
     def handle(self, *args, **kwargs):
+        """
+        Executes the command to import thumbnails from a folder.
+        """
         thumb_folder = settings.THUMBNAILS_FOLDER_PATH
         if not os.path.exists(thumb_folder):
             logger.error(f"Folder {thumb_folder} not found. Stop")

--- a/backend/catalogo_arqueologico/piezas/models.py
+++ b/backend/catalogo_arqueologico/piezas/models.py
@@ -23,12 +23,12 @@ Each model is designed to capture specific details and relationships necessary f
 artifacts within the system.
 """
 
+import logging
 from django.db import models
 from django.contrib.auth.models import AbstractUser
 from django.conf import settings
 from django.contrib.auth.models import Group
 from .validators import validateRut
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/backend/catalogo_arqueologico/piezas/models.py
+++ b/backend/catalogo_arqueologico/piezas/models.py
@@ -1,3 +1,28 @@
+"""
+This module defines the models used in the Django application.
+
+Models:
+- CustomUser: Extends Django's AbstractUser to include additional fields like role, 
+    institution, and a RUT field with custom validation.
+- Shape: Represents the shape of an artifact with a unique name.
+- Culture: Represents the culture associated with an artifact with a unique name.
+- Tag: Represents a tag that can be associated with an artifact with a unique name.
+- Thumbnail: Represents a thumbnail image for an artifact with a unique path.
+- Model: Represents a 3D model of an artifact with unique attributes for texture, 
+    object file, and material file.
+- Image: Represents an image associated with an artifact with a unique path.
+- Artifact: Represents an artifact with a description and relationships to other models 
+    like Thumbnail, Model, Shape, Culture, and Tags.
+- TagsIds, CultureIds, ShapeIds: Auxiliary tables to store unique relationships 
+    between artifacts and tags, cultures, or shapes.
+- Institution: Represents an institution with a unique name.
+- ArtifactRequester: Represents a requester of an artifact with details like name, 
+    RUT, email, comments, registration status, and relationships to Institution and Artifact.
+
+Each model is designed to capture specific details and relationships necessary for managing 
+artifacts within the system.
+"""
+
 from django.db import models
 from django.contrib.auth.models import AbstractUser
 from django.conf import settings
@@ -9,7 +34,24 @@ logger = logging.getLogger(__name__)
 
 
 class CustomUser(AbstractUser):
+    """
+    Custom user model extending Django's AbstractUser.
+
+    Adds additional fields and functionality to the default user model,
+    including a role field with predefined choices, an institution field,
+    and a RUT field with custom validation.
+
+    Attributes:
+        role (CharField): User's role within the system, limited to predefined choices.
+        institution (CharField): Name of the institution the user is associated with.
+        rut (CharField): Unique identifier for the user, validated by a custom validator.
+    """
+
     class RoleUser(models.TextChoices):
+        """
+        RoleUser class to store the predefined choices for the user's role.
+        """
+
         FUNCIONARIO = "FN", "FUNCIONARIO"
         ADMINISTRADOR = "AD", "ADMIN"
 
@@ -25,6 +67,12 @@ class CustomUser(AbstractUser):
     )
 
     def update_group(self):
+        """
+        Updates the user's group membership based on their role.
+
+        Clears existing groups and assigns a new group based on the user's role.
+        Logs the process.
+        """
         self.groups.clear()
         logger.info(f"Updating group for user {self.username} with role {self.role}")
         new_group = None
@@ -40,6 +88,16 @@ class CustomUser(AbstractUser):
         logger.info(f"User groups after update: {list(self.groups.all())}")
 
     def save(self, *args, **kwargs):
+        """
+        Save method for the CustomUser model.
+
+        Overrides the default save method to ensure new users are marked as
+        staff and to update group membership based on role.
+
+        Parameters:
+            args: Variable length argument list.
+            kwargs: Arbitrary keyword arguments.
+        """
         # New user
         if not self.pk:
             self.is_staff = (
@@ -55,8 +113,13 @@ class CustomUser(AbstractUser):
 
 class Shape(models.Model):
     """
-    Shape model to store the shapes of the artifacts
-    Name must be unique
+    Represents the shape of an artifact.
+
+    Name must be unique.
+
+    Attributes:
+        id (BigAutoField): Primary key.
+        name (CharField): Unique name of the shape.
     """
 
     id = models.BigAutoField(primary_key=True)
@@ -65,8 +128,13 @@ class Shape(models.Model):
 
 class Culture(models.Model):
     """
-    Culture model to store the cultures of the artifacts
-    Name must be unique
+    Represents the culture associated with an artifact.
+
+    Name must be unique.
+
+    Attributes:
+        id (BigAutoField): Primary key.
+        name (CharField): Unique name of the culture.
     """
 
     id = models.BigAutoField(primary_key=True)
@@ -75,8 +143,13 @@ class Culture(models.Model):
 
 class Tag(models.Model):
     """
-    Tag model to store the tags of the artifacts
-    Name must be unique
+    Represents a tag that can be associated with an artifact.
+
+    Name must be unique.
+
+    Attributes:
+        id (BigAutoField): Primary key.
+        path (ImageField): Path to the thumbnail image, must be unique.
     """
 
     id = models.BigAutoField(primary_key=True)
@@ -85,8 +158,13 @@ class Tag(models.Model):
 
 class Thumbnail(models.Model):
     """
-    Thumbnail model to store the thumbnails of the artifacts
-    Images must be unique
+    Represents a thumbnail image for an artifact.
+
+    Images must be unique.
+
+    Attributes:
+        id (BigAutoField): Primary key.
+        path (ImageField): Path to the thumbnail image, must be unique.
     """
 
     id = models.BigAutoField(primary_key=True)
@@ -95,8 +173,15 @@ class Thumbnail(models.Model):
 
 class Model(models.Model):
     """
-    Model to store the 3D models of the artifacts
-    Each attribute must be unique
+    Represents a 3D model of an artifact.
+
+    Each attribute must be unique.
+
+    Attributes:
+        id (BigAutoField): Primary key.
+        texture (ImageField): Path to the texture image.
+        object (FileField): Path to the 3D object file.
+        material (FileField): Path to the material file.
     """
 
     id = models.BigAutoField(primary_key=True)
@@ -107,8 +192,14 @@ class Model(models.Model):
 
 class Image(models.Model):
     """
-    Image model to store the images of the artifacts
-    Images must be unique
+    Represents an image associated with an artifact.
+
+    Images must be unique.
+
+    Attributes:
+        id (BigAutoField): Primary key.
+        id_artifact (ForeignKey): Reference to the associated artifact.
+        path (ImageField): Path to the image, must be unique.
     """
 
     id = models.BigAutoField(primary_key=True)
@@ -120,7 +211,16 @@ class Image(models.Model):
 
 class Artifact(models.Model):
     """
-    Artifact model to store the artifacts
+    Represents an artifact.
+
+    Attributes:
+        id (BigAutoField): Primary key.
+        description (CharField): Description of the artifact.
+        id_thumbnail (ForeignKey): Reference to the associated Thumbnail.
+        id_model (ForeignKey): Reference to the associated Model.
+        id_shape (ForeignKey): Reference to the associated Shape.
+        id_culture (ForeignKey): Reference to the associated Culture.
+        id_tags (ManyToManyField): Tags associated with the artifact.
     """
 
     id = models.BigAutoField(primary_key=True)
@@ -145,8 +245,17 @@ class Artifact(models.Model):
 
 class TagsIds(models.Model):
     """
-    Auxiliary table to store the relationship between the tag and the artifact
-    Tag and ArtifactId must be unique together
+    Auxiliary table to store the relationship between the tag and the artifact.
+
+    Tag and ArtifactId must be unique together.
+
+    Attributes:
+        id (BigAutoField): Primary key.
+        tag (IntegerField): Represents the tag.
+        artifactid (IntegerField): Represents the associated artifact.
+
+    Meta:
+        constraints (UniqueConstraint): Ensures the combination of tag and artifactid is unique.
     """
 
     id = models.BigAutoField(primary_key=True)
@@ -154,6 +263,13 @@ class TagsIds(models.Model):
     artifactid = models.IntegerField()
 
     class Meta:
+        """
+        Meta class for the TagsIds model.
+
+        Attributes:
+            constraints (list): List of constraints for the model.
+        """
+
         constraints = [
             models.UniqueConstraint(
                 fields=["tag", "artifactid"], name="unique_tag_artifact"
@@ -163,8 +279,17 @@ class TagsIds(models.Model):
 
 class CultureIds(models.Model):
     """
-    Auxiliary table to store the relationship between the culture and the artifact
-    Culture and ArtifactId must be unique together
+    Auxiliary table to store the relationship between the culture and the artifact.
+
+    Culture and ArtifactId must be unique together.
+
+    Attributes:
+        id (BigAutoField): Primary key.
+        culture (IntegerField): Represents the culture.
+        artifactid (IntegerField): Represents the associated artifact.
+
+    Meta:
+        constraints (UniqueConstraint): Ensures the combination of culture and artifactid is unique.
     """
 
     id = models.BigAutoField(primary_key=True)
@@ -172,6 +297,13 @@ class CultureIds(models.Model):
     artifactid = models.IntegerField()
 
     class Meta:
+        """
+        Meta class for the CultureIds model.
+
+        Attributes:
+            constraints (list): List of constraints for the model.
+        """
+
         constraints = [
             models.UniqueConstraint(
                 fields=["culture", "artifactid"], name="unique_culture_artifact"
@@ -181,8 +313,17 @@ class CultureIds(models.Model):
 
 class ShapeIds(models.Model):
     """
-    Auxiliary table to store the relationship between the shape and the artifact
-    Shape and ArtifactId must be unique together
+    Auxiliary table to store the relationship between the shape and the artifact.
+
+    Shape and ArtifactId must be unique together.
+
+    Attributes:
+        id (BigAutoField): Primary key.
+        shape (IntegerField): Represents the shape.
+        artifactid (IntegerField): Represents the associated artifact.
+
+    Meta:
+        constraints (UniqueConstraint): Ensures the combination of shape and artifactid is unique.
     """
 
     id = models.BigAutoField(primary_key=True)
@@ -190,6 +331,13 @@ class ShapeIds(models.Model):
     artifactid = models.IntegerField()
 
     class Meta:
+        """
+        Meta class for the ShapeIds model.
+
+        Attributes:
+            constraints (list): List of constraints for the model.
+        """
+
         constraints = [
             models.UniqueConstraint(
                 fields=["shape", "artifactid"], name="unique_shape_artifact"
@@ -198,11 +346,33 @@ class ShapeIds(models.Model):
 
 
 class Institution(models.Model):
+    """
+    Represents an institution.
+
+    Attributes:
+        id (BigAutoField): Primary key.
+        name (CharField): Unique name of the institution.
+    """
+
     id = models.BigAutoField(primary_key=True)
     name = models.CharField(max_length=100, unique=True)
 
 
 class ArtifactRequester(models.Model):
+    """
+    Represents a requester of an artifact.
+
+    Attributes:
+        id (BigAutoField): Primary key.
+        name (CharField): Name of the requester.
+        rut (CharField): RUT of the requester.
+        email (EmailField): Email of the requester.
+        comments (TextField): Optional comments from the requester.
+        is_registered (BooleanField): Indicates if the requester is registered.
+        institution (ForeignKey): Reference to the associated institution.
+        artifact (ForeignKey): Reference to the requested artifact.
+    """
+
     id = models.BigAutoField(primary_key=True)
     name = models.CharField(max_length=50)
     rut = models.CharField(max_length=50)

--- a/backend/catalogo_arqueologico/piezas/models.py
+++ b/backend/catalogo_arqueologico/piezas/models.py
@@ -14,7 +14,7 @@ Models:
 - Artifact: Represents an artifact with a description and relationships to other models 
     like Thumbnail, Model, Shape, Culture, and Tags.
 - TagsIds, CultureIds, ShapeIds: Auxiliary tables to store unique relationships 
-    between artifacts and tags, cultures, or shapes.
+    between artifacts and tags, cultures, or shapes when importing.
 - Institution: Represents an institution with a unique name.
 - ArtifactRequester: Represents a requester of an artifact with details like name, 
     RUT, email, comments, registration status, and relationships to Institution and Artifact.
@@ -245,7 +245,7 @@ class Artifact(models.Model):
 
 class TagsIds(models.Model):
     """
-    Auxiliary table to store the relationship between the tag and the artifact.
+    Auxiliary table to store the relationship between the tag and the artifact when importing.
 
     Tag and ArtifactId must be unique together.
 
@@ -279,7 +279,7 @@ class TagsIds(models.Model):
 
 class CultureIds(models.Model):
     """
-    Auxiliary table to store the relationship between the culture and the artifact.
+    Auxiliary table to store the relationship between the culture and the artifact when importing.
 
     Culture and ArtifactId must be unique together.
 
@@ -313,7 +313,7 @@ class CultureIds(models.Model):
 
 class ShapeIds(models.Model):
     """
-    Auxiliary table to store the relationship between the shape and the artifact.
+    Auxiliary table to store the relationship between the shape and the artifact when importing.
 
     Shape and ArtifactId must be unique together.
 

--- a/backend/catalogo_arqueologico/piezas/models.py
+++ b/backend/catalogo_arqueologico/piezas/models.py
@@ -94,7 +94,7 @@ class CustomUser(AbstractUser):
         Overrides the default save method to ensure new users are marked as
         staff and to update group membership based on role.
 
-        Parameters:
+        Args:
             args: Variable length argument list.
             kwargs: Arbitrary keyword arguments.
         """

--- a/backend/catalogo_arqueologico/piezas/permissions.py
+++ b/backend/catalogo_arqueologico/piezas/permissions.py
@@ -22,7 +22,7 @@ class IsFuncionarioPermission(permissions.BasePermission):
         """
         Checks if the requesting user belongs to the "Funcionario" group.
 
-        Parameters:
+        Args:
         - request: HttpRequest object.
         - view: The view which is being accessed.
 
@@ -44,7 +44,7 @@ class IsAdminPermission(permissions.BasePermission):
         """
         Checks if the requesting user belongs to the "Administrador" group.
 
-        Parameters:
+        Args:
         - request: HttpRequest object.
         - view: The view which is being accessed.
 

--- a/backend/catalogo_arqueologico/piezas/permissions.py
+++ b/backend/catalogo_arqueologico/piezas/permissions.py
@@ -1,13 +1,56 @@
+"""
+This module defines custom permission classes for a Django REST Framework application, 
+ensuring that only users belonging to specific groups can access certain views.
+
+Classes:
+- IsFuncionarioPermission: Grants permission to users who are part of the "Funcionario" group.
+- IsAdminPermission: Grants permission to users who are part of the "Administrador" group.
+"""
+
 from rest_framework import permissions
 
 
 class IsFuncionarioPermission(permissions.BasePermission):
+    """
+    Permission class to restrict access to users who are part of the "Funcionario" group.
+
+    This class checks if the requesting user is a member of the "Funcionario" group and
+    grants access accordingly.
+    """
+
     def has_permission(self, request, view):
+        """
+        Checks if the requesting user belongs to the "Funcionario" group.
+
+        Parameters:
+        - request: HttpRequest object.
+        - view: The view which is being accessed.
+
+        Returns:
+        - bool: True if the user is in the "Funcionario" group, False otherwise.
+        """
         return request.user and request.user.groups.filter(name="Funcionario").exists()
 
 
 class IsAdminPermission(permissions.BasePermission):
+    """
+    Permission class to restrict access to users who are part of the "Administrador" group.
+
+    This class checks if the requesting user is a member of the "Administrador" group
+    and grants access accordingly.
+    """
+
     def has_permission(self, request, view):
+        """
+        Checks if the requesting user belongs to the "Administrador" group.
+
+        Parameters:
+        - request: HttpRequest object.
+        - view: The view which is being accessed.
+
+        Returns:
+        - bool: True if the user is in the "Administrador" group, False otherwise.
+        """
         return (
             request.user and request.user.groups.filter(name="Administrador").exists()
         )

--- a/backend/catalogo_arqueologico/piezas/serializers.py
+++ b/backend/catalogo_arqueologico/piezas/serializers.py
@@ -25,9 +25,10 @@ Serializers Included:
 - ArtifactRequesterSerializer: Handles serialization for ArtifactRequester model instances.
 """
 
-import os
-from django.conf import settings
-from django.core.files import File
+import os  # unused import
+import logging
+from django.conf import settings  # unused import
+from django.core.files import File  # unused import
 from rest_framework import serializers
 from .models import (
     ArtifactRequester,
@@ -35,12 +36,11 @@ from .models import (
     Shape,
     Culture,
     Artifact,
-    Model,
+    Model,  # unused import
     Thumbnail,
     Image,
     Institution,
 )
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/backend/catalogo_arqueologico/piezas/serializers.py
+++ b/backend/catalogo_arqueologico/piezas/serializers.py
@@ -2,7 +2,17 @@ import os
 from django.conf import settings
 from django.core.files import File
 from rest_framework import serializers
-from .models import ArtifactRequester, Tag, Shape, Culture, Artifact, Model, Thumbnail, Image, Institution
+from .models import (
+    ArtifactRequester,
+    Tag,
+    Shape,
+    Culture,
+    Artifact,
+    Model,
+    Thumbnail,
+    Image,
+    Institution,
+)
 import logging
 
 logger = logging.getLogger(__name__)

--- a/backend/catalogo_arqueologico/piezas/serializers.py
+++ b/backend/catalogo_arqueologico/piezas/serializers.py
@@ -1,3 +1,30 @@
+"""
+This module defines serializers for various models related to an artifact cataloging system.
+
+It includes serializers for models such as Shape, Culture, Tag, Thumbnail, Artifact, and others,
+facilitating the serialization and deserialization of these models for API responses and requests.
+The serializers handle converting complex model instances into JSON format for easy rendering by
+front-end applications, as well as parsing JSON data to update or create model instances.
+
+The module utilizes Django REST Framework's serializers for model serialization, providing methods
+to define custom fields, validation, and object creation or updating logic. It supports full CRUD
+operations on the Artifact model and related entities, ensuring data integrity and consistency 
+across the application's API.
+
+Serializers Included:
+- ShapeSerializer: Handles serialization for Shape model instances.
+- CultureSerializer: Handles serialization for Culture model instances.
+- TagSerializer: Handles serialization for Tag model instances.
+- ThumbnailSerializer: Handles serialization for Thumbnail model instances.
+- ArtifactSerializer: Handles serialization for Artifact model instances, including custom methods
+  to serialize related objects like tags, thumbnails, models, and images.
+- CatalogSerializer: Provides a simplified serializer for listing artifacts in a catalog view,
+  including key attributes and thumbnails.
+- UpdateArtifactSerializer: Supports updating existing Artifact instances with partial or full data.
+- InstitutionSerializer: Handles serialization for Institution model instances.
+- ArtifactRequesterSerializer: Handles serialization for ArtifactRequester model instances.
+"""
+
 import os
 from django.conf import settings
 from django.core.files import File
@@ -19,36 +46,102 @@ logger = logging.getLogger(__name__)
 
 
 class ShapeSerializer(serializers.ModelSerializer):
+    """
+    Serializer for the Shape model.
+    """
+
     class Meta:
+        """
+        Meta class for the ShapeSerializer.
+
+        Attributes:
+        - model: The Shape model to serialize.
+        - fields: The fields to include in the serialized data.
+        """
+
         model = Shape
         fields = "__all__"
 
 
 class CultureSerializer(serializers.ModelSerializer):
+    """
+    Serializer for the Culture model.
+    """
+
     class Meta:
+        """
+        Meta class for the CultureSerializer.
+
+        Attributes:
+        - model: The Culture model to serialize.
+        - fields: The fields to include in the serialized data.
+        """
+
         model = Culture
         fields = "__all__"
 
 
 class TagSerializer(serializers.ModelSerializer):
+    """
+    Serializer for the Tag model.
+    """
+
     class Meta:
+        """
+        Meta class for the TagSerializer.
+
+        Attributes:
+        - model: The Tag model to serialize.
+        - fields: The fields to include in the serialized data.
+        """
+
         model = Tag
         fields = "__all__"
 
 
 class ThumbnailSerializer(serializers.ModelSerializer):
+    """
+    Serializer for the Thumbnail model.
+    """
+
     class Meta:
+        """
+        Meta class for the ThumbnailSerializer.
+
+        Attributes:
+        - model: The Thumbnail model to serialize.
+        - fields: The fields to include in the serialized data.
+        """
+
         model = Thumbnail
         fields = "__all__"
 
 
 class ArtifactSerializer(serializers.ModelSerializer):
+    """
+    Serializer for the Artifact model.
+
+    Attributes:
+    - attributes: The attributes of the artifact.
+    - thumbnail: The thumbnail of the artifact.
+    - model: The model of the artifact.
+    - images: The images of the artifact.
+    """
+
     attributes = serializers.SerializerMethodField()
     thumbnail = serializers.SerializerMethodField()
     model = serializers.SerializerMethodField()
     images = serializers.SerializerMethodField()
 
     class Meta:
+        """
+        Meta class for the ArtifactSerializer.
+
+        Attributes:
+        - model: The Artifact model to serialize.
+        - fields: The fields to include in the serialized data.
+        """
+
         model = Artifact
         fields = [
             "id",
@@ -59,6 +152,15 @@ class ArtifactSerializer(serializers.ModelSerializer):
         ]
 
     def get_attributes(self, instance):
+        """
+        Method to obtain the attributes of the artifact.
+
+        Args:
+        - instance: The instance of the artifact.
+
+        Returns:
+        - A dictionary with the attributes of the artifact.
+        """
         Tags = [{"id": tag.id, "value": tag.name} for tag in instance.id_tags.all()]
         wholeDict = {
             "shape": {"id": instance.id_shape.id, "value": instance.id_shape.name},
@@ -72,6 +174,15 @@ class ArtifactSerializer(serializers.ModelSerializer):
         return wholeDict
 
     def get_thumbnail(self, instance):
+        """
+        Method to obtain the thumbnail of the artifact.
+
+        Args:
+        - instance: The instance of the artifact.
+
+        Returns:
+        - The URL of the thumbnail of the artifact.
+        """
         if instance.id_thumbnail:
             return self.context["request"].build_absolute_uri(
                 instance.id_thumbnail.path.url
@@ -80,6 +191,15 @@ class ArtifactSerializer(serializers.ModelSerializer):
             return None
 
     def get_model(self, instance):
+        """
+        Method to obtain the model of the artifact.
+
+        Args:
+        - instance: The instance of the artifact.
+
+        Returns:
+        - A dictionary with the URL of the object, material and texture of the model.
+        """
         realModel = instance.id_model
         modelDict = {
             "object": self.context["request"].build_absolute_uri(realModel.object.url),
@@ -93,6 +213,15 @@ class ArtifactSerializer(serializers.ModelSerializer):
         return modelDict
 
     def get_images(self, instance):
+        """
+        Method to obtain the images of the artifact.
+
+        Args:
+        - instance: The instance of the artifact.
+
+        Returns:
+        - A list with the URLs of the images of the artifact.
+        """
         everyImage = Image.objects.filter(id_artifact=instance.id)
         Images = []
         for image in everyImage:
@@ -100,16 +229,42 @@ class ArtifactSerializer(serializers.ModelSerializer):
         return Images
 
 
-# Obtains the json object with the attributes of the artifacts for the catalog
 class CatalogSerializer(serializers.ModelSerializer):
+    """
+    Serializer for the Artifact model.
+
+    Obtains the JSON object with the attributes of the artifacts for the catalog.
+
+    Attributes:
+    - attributes: The attributes of the artifact.
+    - thumbnail: The thumbnail of the artifact.
+    """
+
     attributes = serializers.SerializerMethodField(read_only=True)
     thumbnail = serializers.SerializerMethodField(read_only=True)
 
     class Meta:
+        """
+        Meta class for the CatalogSerializer.
+
+        Attributes:
+        - model: The Artifact model to serialize.
+        - fields: The fields to include in the serialized data.
+        """
+
         model = Artifact
         fields = ["id", "attributes", "thumbnail"]
 
     def get_attributes(self, instance):
+        """
+        Method to obtain the attributes of the artifact.
+
+        Args:
+        - instance: The instance of the artifact.
+
+        Returns:
+        - A dictionary with the attributes of the artifact.
+        """
         shapeInstance = Shape.objects.get(id=instance.id_shape.id)
         tagsInstances = Tag.objects.filter(id__in=instance.id_tags.all())
         cultureInstance = Culture.objects.get(id=instance.id_culture.id)
@@ -127,6 +282,15 @@ class CatalogSerializer(serializers.ModelSerializer):
         return attributes
 
     def get_thumbnail(self, instance):
+        """
+        Method to obtain the thumbnail of the artifact.
+
+        Args:
+        - instance: The instance of the artifact.
+
+        Returns:
+        - The URL of the thumbnail of the artifact.
+        """
         if instance.id_thumbnail:
             return self.context["request"].build_absolute_uri(
                 instance.id_thumbnail.path.url
@@ -136,22 +300,59 @@ class CatalogSerializer(serializers.ModelSerializer):
 
 
 class UpdateArtifactSerializer(serializers.ModelSerializer):
+    """
+    Serializer for the Artifact model.
+
+    Attributes:
+    - description: The description of the artifact.
+    - id_shape: The shape of the artifact.
+    - id_culture: The culture of the artifact.
+    """
+
     description = serializers.CharField()
     id_shape = serializers.PrimaryKeyRelatedField(queryset=Shape.objects.all())
     id_culture = serializers.PrimaryKeyRelatedField(queryset=Culture.objects.all())
 
     class Meta:
+        """
+        Meta class for the UpdateArtifactSerializer.
+
+        Attributes:
+        - model: The Artifact model to serialize.
+        - fields: The fields to include in the serialized data.
+        - extra_kwargs: The extra keyword arguments for the serializer.
+        """
+
         model = Artifact
         fields = ["id", "description", "id_shape", "id_culture", "id_tags"]
         extra_kwargs = {"id_tags": {"required": False}}
 
     def create(self, validated_data):
+        """
+        Method to create an artifact.
+
+        Args:
+        - validated_data: The data to validate.
+
+        Returns:
+        - The instance of the artifact.
+        """
         tags = validated_data.pop("id_tags", [])
         instance = Artifact.objects.create(**validated_data)
         instance.id_tags.set(tags)
         return instance
 
     def update(self, instance, validated_data):
+        """
+        Method to update an artifact.
+
+        Args:
+        - instance: The instance of the artifact.
+        - validated_data: The data to validate.
+
+        Returns:
+        - The instance of the artifact.
+        """
         instance.description = validated_data.get("description", instance.description)
         instance.id_shape = validated_data.get("id_shape", instance.id_shape)
         instance.id_culture = validated_data.get("id_culture", instance.id_culture)
@@ -162,12 +363,36 @@ class UpdateArtifactSerializer(serializers.ModelSerializer):
 
 
 class InstitutionSerializer(serializers.ModelSerializer):
+    """
+    Serializer for the Institution model.
+    """
+
     class Meta:
+        """
+        Meta class for the InstitutionSerializer.
+
+        Attributes:
+        - model: The Institution model to serialize.
+        - fields: The fields to include in the serialized data.
+        """
+
         model = Institution
         fields = ["id", "name"]
 
 
 class ArtifactRequesterSerializer(serializers.ModelSerializer):
+    """
+    Serializer for the ArtifactRequester model.
+    """
+
     class Meta:
+        """
+        Meta class for the ArtifactRequesterSerializer.
+
+        Attributes:
+        - model: The ArtifactRequester model to serialize.
+        - fields: The fields to include in the serialized data.
+        """
+
         model = ArtifactRequester
         fields = "__all__"

--- a/backend/catalogo_arqueologico/piezas/serializers.py
+++ b/backend/catalogo_arqueologico/piezas/serializers.py
@@ -7,9 +7,7 @@ The serializers handle converting complex model instances into JSON format for e
 front-end applications, as well as parsing JSON data to update or create model instances.
 
 The module utilizes Django REST Framework's serializers for model serialization, providing methods
-to define custom fields, validation, and object creation or updating logic. It supports full CRUD
-operations on the Artifact model and related entities, ensuring data integrity and consistency 
-across the application's API.
+to define custom fields, validation, and object creation or updating logic.
 
 Serializers Included:
 - ShapeSerializer: Handles serialization for Shape model instances.

--- a/backend/catalogo_arqueologico/piezas/urls.py
+++ b/backend/catalogo_arqueologico/piezas/urls.py
@@ -1,3 +1,27 @@
+"""
+This module defines URL patterns for the artifact cataloging system's API.
+
+The URL patterns include routes for:
+- API documentation, accessible at the 'docs/' path, which uses Django REST Framework's 
+built-in documentation feature.
+- A catalog view of artifacts, accessible at 'artifacts/', which lists all artifacts 
+available in the system.
+- Artifact upload and update functionality, accessible at 'artifact/upload' and 
+'artifact/<int:pk>/update' respectively, allowing for the creation and modification 
+of artifact records.
+- Detailed views of individual artifacts, accessible at 'artifact/<int:pk>/', providing 
+detailed information about a specific artifact.
+- A list view of metadata, accessible at 'metadata/', which lists all metadata records
+associated with artifacts.
+- An institutions view, accessible at 'institutions/', listing all institutions that 
+have artifacts in the catalog.
+- A download endpoint for artifacts, accessible at 'artifact/<int:pk>/download', allowing 
+for the downloading of artifact data.
+
+Each route is connected to a view from the 'piezas' application, which handles the 
+request and response logic for that endpoint.
+"""
+
 from django.urls import path, include
 from rest_framework.documentation import include_docs_urls
 from rest_framework import routers

--- a/backend/catalogo_arqueologico/piezas/urls.py
+++ b/backend/catalogo_arqueologico/piezas/urls.py
@@ -4,13 +4,12 @@ from rest_framework import routers
 from piezas import views
 
 urlpatterns = [
-    path('docs/', include_docs_urls(title="Metadata API")),
-    path('artifacts/', views.CatalogAPIView.as_view()),
-    path('artifact/upload', views.ArtifactCreateUpdateAPIView.as_view()),
-    path('artifact/<int:pk>/', views.ArtifactDetailAPIView.as_view()),
-    path('artifact/<int:pk>/update', views.ArtifactCreateUpdateAPIView.as_view()),
-    path('metadata/', views.MetadataListAPIView.as_view()),
-    path('institutions/', views.InstitutionAPIView.as_view()),
-    path('artifact/<int:pk>/download', views.ArtifactDownloadAPIView.as_view()),
+    path("docs/", include_docs_urls(title="Metadata API")),
+    path("artifacts/", views.CatalogAPIView.as_view()),
+    path("artifact/upload", views.ArtifactCreateUpdateAPIView.as_view()),
+    path("artifact/<int:pk>/", views.ArtifactDetailAPIView.as_view()),
+    path("artifact/<int:pk>/update", views.ArtifactCreateUpdateAPIView.as_view()),
+    path("metadata/", views.MetadataListAPIView.as_view()),
+    path("institutions/", views.InstitutionAPIView.as_view()),
+    path("artifact/<int:pk>/download", views.ArtifactDownloadAPIView.as_view()),
 ]
-

--- a/backend/catalogo_arqueologico/piezas/urls.py
+++ b/backend/catalogo_arqueologico/piezas/urls.py
@@ -22,9 +22,9 @@ Each route is connected to a view from the 'piezas' application, which handles t
 request and response logic for that endpoint.
 """
 
-from django.urls import path, include
+from django.urls import path, include # unused import include
 from rest_framework.documentation import include_docs_urls
-from rest_framework import routers
+from rest_framework import routers # unused import routers
 from piezas import views
 
 urlpatterns = [

--- a/backend/catalogo_arqueologico/piezas/validators.py
+++ b/backend/catalogo_arqueologico/piezas/validators.py
@@ -1,7 +1,20 @@
+"""
+This module contains a validator for data inputs specific to the 
+application's requirements. 
+
+The validator `validateRut` is designed to validate Chilean RUT (Rol Único Tributario) numbers. 
+"""
+
 from django.core.exceptions import ValidationError
 
 
 def validateRut(rut):
+    """
+    Validates a chilean RUT (Rol Único Tributario) number.
+
+    Args:
+        rut (str): The RUT to validate.
+    """
     if len(rut) != 9:
         raise ValidationError("Invalid identifier: Must be 9 characters long")
     last = rut[8]

--- a/backend/catalogo_arqueologico/piezas/views.py
+++ b/backend/catalogo_arqueologico/piezas/views.py
@@ -1,3 +1,18 @@
+"""
+This module defines API views for handling operations related to Artifacts, Metadata, 
+and Artifact Downloads in the application.
+
+Classes:
+- ArtifactDetailAPIView: Provides a detail view for a single artifact. 
+- MetadataListAPIView: Provides a list view for metadata related to artifacts. 
+- ArtifactDownloadAPIView: Handles both the retrieval of detailed information about 
+    an artifact and the creation of artifact requester records. 
+- CustomPageNumberPagination: Provides paginated responses for API views.
+- CatalogAPIView: Provides a list view for artifacts in the catalog.
+- ArtifactCreateUpdateAPIView: Provides functionality for creating and updating artifacts.
+- InstitutionAPIView: Provides a list view for institutions.
+"""
+
 import os
 from django.conf import settings
 from .authentication import TokenAuthentication
@@ -41,15 +56,54 @@ logger = logging.getLogger(__name__)
 
 
 class ArtifactDetailAPIView(generics.RetrieveAPIView):
+    """
+    A view that provides detail for a single artifact.
+
+    It extends Django REST Framework's RetrieveAPIView.
+
+    Attributes:
+        queryset: Specifies the queryset that this view will use to retrieve
+            the Artifact object. It retrieves all Artifact objects.
+        serializer_class: Specifies the serializer class that should be used
+            for serializing the Artifact object.
+        permission_classes: Defines the list of permissions that apply to
+            this view. It is set to allow any user to access this view.
+    """
+
     queryset = Artifact.objects.all()
     serializer_class = ArtifactSerializer
     permission_classes = [permissions.AllowAny]
 
 
 class MetadataListAPIView(generics.ListAPIView):
+    """
+    A view that provides a list of metadata related to artifacts.
+
+    It extends Django REST Framework's ListAPIView.
+
+    Attributes:
+        permission_classes: Defines the list of permissions that apply to this
+            view. It is set to allow any user to access this view.
+    """
+
     permission_classes = [permissions.AllowAny]
 
     def get(self, request, *args, **kwargs):
+        """
+        Handles GET requests.
+
+        It retrieves all shapes, tags, and cultures from the database, serializes them,
+        and returns them in a response.
+
+        Args:
+            request: The HTTP request object.
+            *args: Variable length argument list.
+            **kwargs: Arbitrary keyword arguments.
+
+        Returns:
+            Response: Django REST Framework's Response object containing serialized
+                data for shapes, tags, and cultures.
+        """
         shapes = Shape.objects.all()
         tags = Tag.objects.all()
         cultures = Culture.objects.all()
@@ -74,12 +128,44 @@ class MetadataListAPIView(generics.ListAPIView):
 
 
 class ArtifactDownloadAPIView(generics.RetrieveAPIView, generics.CreateAPIView):
+    """
+    A view that provides downloaded data of detailed information about an artifact.
+
+    Allows the creation of artifact requester records. It extends Django REST
+    Framework's RetrieveAPIView and CreateAPIView.
+
+    Attributes:
+        queryset: Specifies the queryset that this view will use to retrieve
+            the Artifact object. It retrieves all Artifact objects.
+        serializer_class: Specifies the serializer class that should be used
+            for serializing the Artifact object.
+        lookup_field: Specifies the field that should be used to retrieve a
+            single object from the queryset.
+        permission_classes: Defines the list of permissions that apply to
+            this view. It is set to allow any user to access this view.
+    """
+
     queryset = Artifact.objects.all()
     serializer_class = ArtifactSerializer
     lookup_field = "pk"
     permission_classes = [permissions.AllowAny]
 
     def post(self, request, *args, **kwargs):
+        """
+        Handles POST requests.
+
+        It creates a new artifact requester record and returns a response containing
+        the serialized data for the created artifact requester.
+
+        Args:
+            request: The HTTP request object.
+            *args: Variable length argument list.
+            **kwargs: Arbitrary keyword arguments.
+
+        Returns:
+            Response: Django REST Framework's Response object containing serialized
+                data for the created artifact requester.
+        """
         logger.info(
             "Creating new artifact requester for artifact {}".format(kwargs.get("pk"))
         )
@@ -119,6 +205,21 @@ class ArtifactDownloadAPIView(generics.RetrieveAPIView, generics.CreateAPIView):
         return Response({"data": serializer.data}, status=status.HTTP_201_CREATED)
 
     def get(self, request, *args, **kwargs):
+        """
+        Handles GET requests.
+
+        It retrieves detailed information about an artifact and returns a response
+        containing the serialized data for the artifact.
+
+        Args:
+            request: The HTTP request object.
+            *args: Variable length argument list.
+            **kwargs: Arbitrary keyword arguments.
+
+        Returns:
+            Response: Django REST Framework's Response object containing serialized
+                data for the artifact.
+        """
         pk = kwargs.get("pk")
         if pk is not None:
             logger.info(f"Downloading artifact {pk}")
@@ -163,9 +264,27 @@ class ArtifactDownloadAPIView(generics.RetrieveAPIView, generics.CreateAPIView):
 
 
 class CustomPageNumberPagination(PageNumberPagination):
+    """
+    A custom pagination class that provides paginated responses for API views.
+
+    It extends Django REST Framework's PageNumberPagination.
+
+    Attributes:
+        page_size: Specifies the number of items to display per page.
+    """
+
     page_size = 9
 
     def get_paginated_response(self, data):
+        """
+        Retrieves paginated response data.
+
+        Args:
+            data: The data to be paginated.
+
+        Returns:
+            Response: Django REST Framework's Response object containing paginated data.
+        """
         return Response(
             {
                 "current_page": int(self.request.query_params.get("page", 1)),
@@ -178,11 +297,31 @@ class CustomPageNumberPagination(PageNumberPagination):
 
 
 class CatalogAPIView(generics.ListAPIView):
+    """
+    A view that provides a list of artifacts in the catalog.
+
+    It extends Django REST Framework's ListAPIView.
+
+    Attributes:
+        serializer_class: Specifies the serializer class that should be used
+            for serializing the Artifact objects.
+        pagination_class: Specifies the pagination class that should be used
+            for paginating the response data.
+        permission_classes: Defines the list of permissions that apply to
+            this view. It is set to allow any user to access this view.
+    """
+
     serializer_class = CatalogSerializer
     pagination_class = CustomPageNumberPagination
     permission_classes = [permissions.AllowAny]
 
     def get_queryset(self):
+        """
+        Retrieves the queryset for the view.
+
+        Returns:
+            queryset: The queryset containing all artifacts in the catalog.
+        """
         queryset = Artifact.objects.all().order_by("id")
 
         # Filter by query parameters
@@ -211,9 +350,30 @@ class CatalogAPIView(generics.ListAPIView):
         return queryset.filter(q_objects)
 
     def get_serializer_context(self):
+        """
+        Retrieves the context for the serializer.
+
+        Returns:
+            dict: A dictionary containing the request object.
+        """
         return {"request": self.request}
 
     def get(self, request, *args, **kwargs):
+        """
+        Handles GET requests.
+
+        It retrieves all artifacts in the catalog, serializes them, and returns
+        paginated data in a response.
+
+        Args:
+            request: The HTTP request object.
+            *args: Variable length argument list.
+            **kwargs: Arbitrary keyword arguments.
+
+        Returns:
+            Response: Django REST Framework's Response object containing paginated
+                data for the artifacts.
+        """
         queryset = self.filter_queryset(self.get_queryset())
         page = self.paginate_queryset(queryset)
         if page is not None:
@@ -226,6 +386,25 @@ class CatalogAPIView(generics.ListAPIView):
 
 
 class ArtifactCreateUpdateAPIView(generics.GenericAPIView):
+    """
+    A view that provides functionality for creating and updating artifacts.
+
+    It extends Django REST Framework's GenericAPIView.
+
+    Attributes:
+        queryset: Specifies the queryset that this view will use to retrieve
+            the Artifact objects. It retrieves all Artifact objects.
+        serializer_class: Specifies the serializer class that should be used
+            for serializing the Artifact objects.
+        lookup_field: Specifies the field that should be used to retrieve a
+            single object from the queryset.
+        authentication_classes: Defines the list of authentication classes that
+            apply to this view. It is set to TokenAuthentication.
+        permission_classes: Defines the list of permissions that apply to
+            this view. It is set to allow only authenticated users with the
+            role of 'Funcionario' or 'Administrador' to access this view.
+    """
+
     queryset = Artifact.objects.all()
     serializer_class = UpdateArtifactSerializer
     lookup_field = "pk"
@@ -235,21 +414,84 @@ class ArtifactCreateUpdateAPIView(generics.GenericAPIView):
     ]
 
     def get_object(self):
+        """
+        Retrieves the object for the view.
+
+        Returns:
+            object: The object retrieved from the queryset based on the primary key.
+        """
         pk = self.kwargs.get("pk")
         if pk is not None:
             return super().get_object()
         return None
 
     def post(self, request, *args, **kwargs):
+        """
+        Handles POST requests.
+
+        It creates a new artifact and returns a response containing the serialized
+        data for the created artifact.
+
+        Args:
+            request: The HTTP request object.
+            *args: Variable length argument list.
+            **kwargs: Arbitrary keyword arguments.
+
+        Returns:
+            Response: Django REST Framework's Response object containing serialized
+                data for the created artifact.
+        """
         return self.create_or_update(request, *args, **kwargs)
 
     def put(self, request, *args, **kwargs):
+        """
+        Handles PUT requests.
+
+        It updates an existing artifact and returns a response containing the serialized
+        data for the updated artifact.
+
+        Args:
+            request: The HTTP request object.
+            *args: Variable length argument list.
+            **kwargs: Arbitrary keyword arguments.
+
+        Returns:
+            Response: Django REST Framework's Response object containing serialized
+                data for the updated artifact.
+        """
         return self.create_or_update(request, *args, **kwargs)
 
     def patch(self, request, *args, **kwargs):
+        """
+        Handles PATCH requests.
+
+        It partially updates an existing artifact and returns a response containing the
+        serialized data for the updated artifact.
+
+        Args:
+            request: The HTTP request object.
+            *args: Variable length argument list.
+            **kwargs: Arbitrary keyword arguments.
+
+        Returns:
+            Response: Django REST Framework's Response object containing serialized
+                data for the updated artifact.
+        """
         return self.create_or_update(request, *args, **kwargs, partial=True)
 
     def create_or_update(self, request, *args, **kwargs):
+        """
+        Creates or updates an artifact based on the request data.
+
+        Args:
+            request: The HTTP request object.
+            *args: Variable length argument list.
+            **kwargs: Arbitrary keyword arguments.
+
+        Returns:
+            Response: Django REST Framework's Response object containing serialized
+                data for the created or updated artifact.
+        """
         partial = kwargs.pop("partial", False)
         instance = self.get_object()
 
@@ -282,9 +524,23 @@ class ArtifactCreateUpdateAPIView(generics.GenericAPIView):
         )
 
     def perform_create_or_update(self, serializer):
+        """
+        Performs the creation or update of an artifact based on the serializer.
+
+        Args:
+            serializer: The serializer object that contains the data for the artifact.
+        """
         serializer.save()
 
     def handle_file_uploads(self, instance, files, data):
+        """
+        Handles file uploads for an artifact.
+
+        Args:
+            instance: The Artifact object for which the file uploads are being handled.
+            files: The files to be uploaded.
+            data: The data associated with the files.
+        """
         # Handle thumbnail
         thumbnail_data = files.get("new_thumbnail")
         if thumbnail_data:
@@ -390,11 +646,39 @@ class ArtifactCreateUpdateAPIView(generics.GenericAPIView):
 
 
 class InstitutionAPIView(generics.ListCreateAPIView):
+    """
+    A view that provides a list of institutions.
+
+    It extends Django REST Framework's ListCreateAPIView.
+
+    Attributes:
+        queryset: Specifies the queryset that this view will use to retrieve
+            the Institution objects. It retrieves all Institution objects.
+        serializer_class: Specifies the serializer class that should be used
+            for serializing the Institution objects.
+        permission_classes: Defines the list of permissions that apply to
+            this view. It is set to allow any user to access this view.
+    """
+
     queryset = Institution.objects.all().order_by("id")
     serializer_class = InstitutionSerializer
     permission_classes = [permissions.AllowAny]
 
     def get(self, request, *args, **kwargs):
+        """
+        Handles GET requests.
+
+        It retrieves all institutions, serializes them, and returns them in a response.
+
+        Args:
+            request: The HTTP request object.
+            *args: Variable length argument list.
+            **kwargs: Arbitrary keyword arguments.
+
+        Returns:
+            Response: Django REST Framework's Response object containing serialized
+                data for the institutions.
+        """
         institutions = Institution.objects.all()
 
         # Serialize the data

--- a/backend/catalogo_arqueologico/piezas/views.py
+++ b/backend/catalogo_arqueologico/piezas/views.py
@@ -13,10 +13,19 @@ Classes:
 - InstitutionAPIView: Provides a list view for institutions.
 """
 
+import math
+import zipfile
+from io import BytesIO
+import logging
+import os
 from rest_framework import permissions, generics, status
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.response import Response
 from rest_framework.authtoken.models import Token
+from django.db.models import Q
+from django.core.files import File
+from django.http import HttpResponse
+from django.conf import settings
 from .serializers import (
     ArtifactRequesterSerializer,
     ArtifactSerializer,
@@ -39,16 +48,7 @@ from .models import (
     Model,
     Thumbnail,
 )
-from django.db.models import Q
-from django.core.files import File
-from django.http import HttpResponse
 from .permissions import IsFuncionarioPermission, IsAdminPermission
-import math
-import zipfile
-from io import BytesIO
-import logging
-import os
-from django.conf import settings
 from .authentication import TokenAuthentication
 
 logger = logging.getLogger(__name__)

--- a/backend/catalogo_arqueologico/piezas/views.py
+++ b/backend/catalogo_arqueologico/piezas/views.py
@@ -13,11 +13,7 @@ Classes:
 - InstitutionAPIView: Provides a list view for institutions.
 """
 
-import os
-from django.conf import settings
-from .authentication import TokenAuthentication
-from rest_framework import generics, permissions
-from rest_framework import generics, status
+from rest_framework import permissions, generics, status
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.response import Response
 from rest_framework.authtoken.models import Token
@@ -51,6 +47,9 @@ import math
 import zipfile
 from io import BytesIO
 import logging
+import os
+from django.conf import settings
+from .authentication import TokenAuthentication
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Documentation was added following common Python's documentation style for modules, classes and its methods with help of pylint and copylot.

VSCode's extension "Black Formatter" was used to format the style of python's code. This includes changing literal strings using ' to ". 

Different commits where used for each change in order to avoid messing up with the previous code and make error detection easier.

Some comments were added regarding unused imports which should be deleted. I didn't delete them in case those were some necessary imports I wasn't aware of. 